### PR TITLE
Add URL encode to RSS URL

### DIFF
--- a/src/settings.yml
+++ b/src/settings.yml
@@ -4,7 +4,7 @@ no_screen_padding: 'no'
 dark_mode: 'no'
 static_data: ''
 polling_verb: get
-polling_url: https://rsstojson-lake.vercel.app/api/rss?url={{ rss_url }}
+polling_url: https://rsstojson-lake.vercel.app/api/rss?url={{ rss_url | url_encode }}
 polling_headers: ''
 polling_body: ''
 id: 79118


### PR DESCRIPTION
This pull request updates the `polling_url` configuration in `src/settings.yml` to ensure the `rss_url` parameter is properly URL-encoded before being sent to the API. This helps prevent issues with query parameter strings in RSS feed URLs.

* Updated the `polling_url` value to use the `url_encode` filter for the `rss_url` parameter, improving reliability when handling URLs with special characters.